### PR TITLE
Explaining installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ Highlights every line with a cursor in Atom's [minimap](https://atom.io/packages
 
 ![Minimap cursorline Screenshot](https://github.com/atom-minimap/minimap-cursorline/blob/master/screenshot.gif?raw=true)
 
-Installation
-
-Add a CSS rule to your `styles.less`:
+Depending on your [Atom theme](https://atom.io/themes/) you might need to add a CSS rule to your `styles.less`:
 
 ```css
 .minimap .cursor-line {

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # minimap-cursorline package [![Build Status](https://travis-ci.org/atom-minimap/minimap-cursorline.svg?branch=master)](https://travis-ci.org/atom-minimap/minimap-cursorline)
 
-Displays Atom cursorline in the minimap.
+Highlights the current line in Atom's [minimap](https://github.com/atom-minimap/minimap).
 
 ![Minimap cursorline Screenshot](https://github.com/atom-minimap/minimap-cursorline/blob/master/screenshot.gif?raw=true)
 
-Customization
+Installation
 
-If you want to change the color of the minimap `cursorline` use the following
-CSS rules in your user stylesheet:
+Add a CSS rule to your `styles.less`:
 
 ```css
 .minimap .cursor-line {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # minimap-cursorline package [![Build Status](https://travis-ci.org/atom-minimap/minimap-cursorline.svg?branch=master)](https://travis-ci.org/atom-minimap/minimap-cursorline)
 
-Highlights the current line in Atom's [minimap](https://github.com/atom-minimap/minimap).
+Highlights every line with a cursor in Atom's [minimap](https://atom.io/packages/minimap).
 
 ![Minimap cursorline Screenshot](https://github.com/atom-minimap/minimap-cursorline/blob/master/screenshot.gif?raw=true)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # minimap-cursorline package [![Build Status](https://travis-ci.org/atom-minimap/minimap-cursorline.svg?branch=master)](https://travis-ci.org/atom-minimap/minimap-cursorline)
 
-Highlights every line with a cursor in Atom's [minimap](https://atom.io/packages/minimap).
+Highlights the current line(s) with a cursor in Atom's [minimap](https://atom.io/packages/minimap).
 
 ![Minimap cursorline Screenshot](https://github.com/atom-minimap/minimap-cursorline/blob/master/screenshot.gif?raw=true)
 


### PR DESCRIPTION
Reason: In my case it was *necessary* to add this to `styles.less` (the cursorline didn't show up before)